### PR TITLE
Fix

### DIFF
--- a/app/src/main/java/io/token/sample/Application.java
+++ b/app/src/main/java/io/token/sample/Application.java
@@ -228,7 +228,7 @@ public class Application {
                 .map(p -> p.replace("_", ":")) // member ID
                 .findFirst()
                 .map(memberId -> loadMember(tokenClient, memberId))
-                .orElse(createMember(tokenClient));
+                .orElseGet(() -> createMember(tokenClient));
     }
 
     /**


### PR DESCRIPTION
`orElse()` still runs the function in the parameter even if the result of `map()` is not an empty `Optional`, so we are still creating a new member even if `loadMember` succeeds. Got some Alias related bugs while debugging a support ticket and turns out this was the issue. Clients copy this code so we should fix it.